### PR TITLE
[Bugfix] Use the original order of retrieved tracks of a playlist

### DIFF
--- a/lib/src/playlists/playlist_client.dart
+++ b/lib/src/playlists/playlist_client.dart
@@ -76,7 +76,7 @@ class PlaylistClient {
       final response = await _http.get(uri);
       final actualTracks = jsonDecode(response.body) as List;
       
-      yield actualTracks.map((t) => Track.fromJson(t));
+      yield batchIds.map((id) => Track.fromJson(actualTracks.where((t) => t["id"] == id).single));
 
       continuationOffset += actualTracks.length;
     }


### PR DESCRIPTION
When calling PlaylistClient.getTracks, the retrieved Tracks are not ordered correctly.
This seems to be caused by the Soundcloud API.

This change orders the Tracks correctly before yielding the current batch.